### PR TITLE
fix Stderr::with_config(), README.md and set grid_driver.rs to use updated with_config() interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ use stderr::{Stderr, StderrConfig}; // import StderrConfig or use default
 
 fn main() {
     let config = StderrConfig {
-        quiet: true,
-        debug: false,
-        trace: false,
-        silly: false,
+        quiet: true, // when true silences all output
+        debug: false, // when true enables .debug() output
+        trace: false, // when true enables .trace() output
+        silly: false, // when true enables .magic() output
+        dev: false, // when true enables .devlog() output
     };
 
     let mut stderr = Stderr::with_config(config); //can also just call it logger
@@ -47,7 +48,7 @@ use stderr::Stderr;
 
 fn main() {
     let mut logger = Stderr::new();
-    logger.info("This is so clean!").unwrap();
+    logger.info("This is so clean!");
 }
 ```
 
@@ -95,7 +96,7 @@ if stderr.confirm_builder(prompt)
       .ask()?
       .unwrap_or(false)
 {
-    stderr.warn("Erasing all data...")?;
+    stderr.warn("Erasing all data...");
 }
 ```
 

--- a/examples/grid_driver.rs
+++ b/examples/grid_driver.rs
@@ -15,7 +15,7 @@ fn main() -> io::Result<()> {
     );
 
 
-    let mut logger = Stderr::new().with_config(Config::default());
+    let mut logger = Stderr::with_config(Config::default());
 
     print_color_grid(&mut logger, 6)?;
 

--- a/src/rdx/stderr.rs
+++ b/src/rdx/stderr.rs
@@ -122,7 +122,7 @@ impl Stderr {
     }
 
     /// Creates a new logger with a specific, user-provided configuration.
-    pub fn with_config(self, config: StderrConfig) -> Self {
+    pub fn with_config(config: StderrConfig) -> Self {
       Self {
         config,
         writer: StandardStream::stderr(ColorChoice::Auto),


### PR DESCRIPTION
Hi!
Your logger is extremely pretty, but the interface has a small issue, and the readme is out of date (`Stderr::log()` and friends don't return a `Result<>`, so don't need an `.unwrap()` or a `?`).

The other option for `Stderr::with_config()` if you want to use it like `Stderr::new().with_config()` then you should use:
```rust
pub fn with_config(&mut self, config: StderrConfig) -> &mut Self {
    self.config = config;
    self
}
```
This is a better solution because it doesn't take the extra time to create a new one, and you can easily call it as:
```rust
let mut logger = Stderr::new().with_config(StderrConfig::default());
// ...
```
or as:
```rust
let mut logger = Stderr::new();
logger = logger.with_config(StderrConfig::default());
// ...
```
or as:
```rust
let mut logger = Stderr::new();
logger.with_config(StderrConfig::default());
// ...
```

However, as I didn't want to change the inner behavior all the much, I took the side of caution and simply had it create a new one entirely and got rid of the `self`.  Let me know if you'd like the second option and I can push that change.